### PR TITLE
add started_at to swoop.thread table, update trigger

### DIFF
--- a/src/swoop/db/migrations/00003_thread_table_schema_change.down.sql
+++ b/src/swoop/db/migrations/00003_thread_table_schema_change.down.sql
@@ -1,0 +1,42 @@
+ALTER TABLE swoop.thread
+DROP COLUMN started_at;
+
+CREATE OR REPLACE FUNCTION swoop.update_thread()
+RETURNS trigger
+LANGUAGE plpgsql VOLATILE
+AS $$
+DECLARE
+  _latest timestamptz;
+  _next_attempt timestamptz;
+BEGIN
+  SELECT last_update FROM swoop.thread WHERE action_uuid = NEW.action_uuid INTO _latest;
+
+  -- If the event time is older than the last update we don't update the thread
+  -- (we can't use a trigger condition to filter this because we don't know the
+  -- last update time from the event alone).
+  IF _latest IS NOT NULL AND NEW.event_time < _latest THEN
+    RETURN NULL;
+  END IF;
+
+  -- If we need a next attempt time let's calculate it
+  IF NEW.retry_seconds IS NOT NULL THEN
+    SELECT NEW.event_time + (NEW.retry_seconds * interval '1 second') INTO _next_attempt;
+  END IF;
+
+  UPDATE swoop.thread as t SET
+    last_update = NEW.event_time,
+    status = NEW.status,
+    next_attempt_after = _next_attempt,
+    error = NEW.error
+  WHERE
+    t.action_uuid = NEW.action_uuid;
+
+  -- We _could_ try to drop the thread lock here, which would be nice for
+  -- swoop-conductor so it didn't have to explicitly unlock, but the unlock
+  -- function raises a warning. Being explicit isn't the worst thing either,
+  -- given the complications with possible relocking and the need for clients
+  -- to stay aware of that possibility.
+
+  RETURN NULL;
+END;
+$$;

--- a/src/swoop/db/migrations/00003_thread_table_schema_change.up.sql
+++ b/src/swoop/db/migrations/00003_thread_table_schema_change.up.sql
@@ -1,0 +1,51 @@
+ALTER TABLE swoop.thread
+ADD COLUMN started_at timestamptz NOT NULL;
+
+CREATE OR REPLACE FUNCTION swoop.update_thread()
+RETURNS trigger
+LANGUAGE plpgsql VOLATILE
+AS $$
+DECLARE
+  _latest timestamptz;
+  _next_attempt timestamptz;
+  _started timestamptz;
+BEGIN
+  SELECT last_update, started_at FROM swoop.thread WHERE action_uuid = NEW.action_uuid
+    INTO _latest, _started;
+
+  -- If the event time is older than the last update we don't update the thread
+  -- (we can't use a trigger condition to filter this because we don't know the
+  -- last update time from the event alone).
+  IF _latest IS NOT NULL AND NEW.event_time < _latest THEN
+    IF NEW.status = 'RUNNING' THEN
+        UPDATE swoop.thread as t SET started_at = NEW.event_time WHERE t.action_uuid = NEW.action_uuid;
+    RETURN NULL;
+  END IF;
+
+  -- If we need a next attempt time let's calculate it
+  IF NEW.retry_seconds IS NOT NULL THEN
+    SELECT NEW.event_time + (NEW.retry_seconds * interval '1 second') INTO _next_attempt;
+  END IF;
+
+  IF _started IS NULL AND NEW.status = 'RUNNING' THEN
+    SELECT  NEW.event_time INTO _started;
+  END IF;
+
+  UPDATE swoop.thread as t SET
+    last_update = NEW.event_time,
+    status = NEW.status,
+    next_attempt_after = _next_attempt,
+    error = NEW.error,
+    started_at = _started
+  WHERE
+    t.action_uuid = NEW.action_uuid;
+
+  -- We _could_ try to drop the thread lock here, which would be nice for
+  -- swoop-conductor so it didn't have to explicitly unlock, but the unlock
+  -- function raises a warning. Being explicit isn't the worst thing either,
+  -- given the complications with possible relocking and the need for clients
+  -- to stay aware of that possibility.
+
+  RETURN NULL;
+END;
+$$;


### PR DESCRIPTION
Add a started_at time to the `swoop.thread `table, rework the update trigger to populate that time from RUNNING events, make sure to accommodate out-of-order events (don't update anything but the started_at time on the thread state if the event is older than the last update). 