### PR TITLE
Use same base image for all Dockerfile stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v7.0.1] - 2023-07-11
+
+### Changed
+
+- Use the same image version for all build stages in the Dockerfile (fixes an
+  issue with libc not found) ([#21])
+
 ## [v7.0.0] - 2023-07-01
 
 ### ⚠️ Breaking Changes
@@ -64,6 +71,8 @@ schema.
 Initial release
 
 [unreleased]: https://github.com/element84/swoop-db/compare/v7.0.0...main
+[unreleased]: https://github.com/element84/swoop-db/compare/v7.0.1...main
+[v7.0.1]: https://github.com/element84/swoop-db/compare/v7.0.0...7.0.1
 [v7.0.0]: https://github.com/element84/swoop-db/compare/v2.0.0...7.0.0
 [v2.0.0]: https://github.com/element84/swoop-db/compare/v0.1.0...2.0.0
 [v0.1.0]: https://github.com/element84/swoop-db/tree/v0.1.0
@@ -73,5 +82,6 @@ Initial release
 [#15]: https://github.com/Element84/swoop-db/pull/15
 [#19]: https://github.com/Element84/swoop-db/pull/19
 [#20]: https://github.com/Element84/swoop-db/pull/20
+[#21]: https://github.com/Element84/swoop-db/pull/21
 
 [dbami]: https://github.com/element84/dbami

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN ./swoop-db-venv/bin/pip install -r requirements.txt
 RUN --mount=source=.git,target=.git,type=bind git clone . clone
 RUN ./swoop-db-venv/bin/pip install ./clone
 
-FROM postgres:15-bullseye
+FROM postgres:15
 # install build deps and pg_partman
 RUN set -x && \
     apt-get update && \


### PR DESCRIPTION
Trying to run swoop-db in the container results in the following error messages:

```
/opt/swoop/db/swoop-db-venv/bin/python3: /lib/aarch64-linux-gnu/libm.so.6: version `GLIBC_2.35' not found (required by /opt/swoop/db/swoop-db-venv/bin/python3)
/opt/swoop/db/swoop-db-venv/bin/python3: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by /opt/swoop/db/swoop-db-venv/bin/python3)
/opt/swoop/db/swoop-db-venv/bin/python3: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /opt/swoop/db/swoop-db-venv/bin/python3)
/opt/swoop/db/swoop-db-venv/bin/python3: /lib/aarch64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /opt/swoop/db/swoop-db-venv/bin/python3)
```

Looks like when I pulled in the newer debian postgres image I neglected to update the swoop-db build step, so its python is linked against the wrong libc. 