### PR TITLE
Properly set env vars in Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [v7.0.2] - 2023-07-12
+
+### Changed
+
+- Properly set required env vars in Dockerfile ([#22])
+
 ## [v7.0.1] - 2023-07-11
 
 ### Changed
@@ -70,8 +76,8 @@ schema.
 
 Initial release
 
-[unreleased]: https://github.com/element84/swoop-db/compare/v7.0.0...main
-[unreleased]: https://github.com/element84/swoop-db/compare/v7.0.1...main
+[unreleased]: https://github.com/element84/swoop-db/compare/v7.0.2...main
+[v7.0.2]: https://github.com/element84/swoop-db/compare/v7.0.1...7.0.2
 [v7.0.1]: https://github.com/element84/swoop-db/compare/v7.0.0...7.0.1
 [v7.0.0]: https://github.com/element84/swoop-db/compare/v2.0.0...7.0.0
 [v2.0.0]: https://github.com/element84/swoop-db/compare/v0.1.0...2.0.0
@@ -83,5 +89,6 @@ Initial release
 [#19]: https://github.com/Element84/swoop-db/pull/19
 [#20]: https://github.com/Element84/swoop-db/pull/20
 [#21]: https://github.com/Element84/swoop-db/pull/21
+[#22]: https://github.com/Element84/swoop-db/pull/22
 
 [dbami]: https://github.com/element84/dbami

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ RUN set -x && \
     tar -xzf pgtap.tar.gz --strip-components 1 && \
     make install
 
-ENV PGDATABASE: "${PGDATABASE:-swoop}"
-ENV PGUSER: "${PGUSER:-postgres}"
+ENV PGDATABASE "${PGDATABASE:-swoop}"
+ENV PGUSER "${PGUSER:-postgres}"
 
 # copy the python venv into this output image and add it's bin to the path
 COPY --from=APP /opt/swoop/db/swoop-db-venv /opt/swoop/db/swoop-db-venv


### PR DESCRIPTION
The syntax of the `ENV` environment variable declaration was still wrong 😭 and the var names had a trailing `:`. This PR fixes the env var issues and I have validated that they work as expected via a local build.