### PR TITLE
update db init and migration job scripts

### DIFF
--- a/bin/db-initialization.py
+++ b/bin/db-initialization.py
@@ -94,14 +94,14 @@ async def post_create_init(conn: asyncpg.Connection, owner_role_name: str) -> No
         REVOKE ALL ON DATABASE swoop FROM PUBLIC;
         REVOKE CREATE ON SCHEMA public FROM PUBLIC;
         CREATE SCHEMA IF NOT EXISTS swoop AUTHORIZATION :dbo;
+        GRANT :dbo TO current_user;
+        SET ROLE :dbo;
         GRANT CONNECT ON DATABASE swoop TO swoop_readwrite;
         GRANT USAGE, CREATE ON SCHEMA swoop TO swoop_readwrite;
         ALTER DEFAULT PRIVILEGES IN SCHEMA swoop GRANT SELECT,
         INSERT, UPDATE, DELETE ON TABLES TO swoop_readwrite;
         ALTER DEFAULT PRIVILEGES IN SCHEMA swoop GRANT USAGE ON
         SEQUENCES TO swoop_readwrite;
-        ALTER DEFAULT PRIVILEGES IN SCHEMA swoop GRANT EXECUTE ON
-        FUNCTIONS TO swoop_readwrite;
         """,
         dbo=V(owner_role_name),
     )

--- a/bin/run-migration-job.py
+++ b/bin/run-migration-job.py
@@ -119,23 +119,24 @@ async def run_migrations() -> None:
     swoop_db = SwoopDB()
 
     async with swoop_db.get_db_connection() as conn:
-        current_version = await swoop_db.get_current_version(conn=conn)
-        if current_version == version:
-            return
+        try:
+            current_version = await swoop_db.get_current_version(conn=conn)
+            if current_version == version:
+                return
 
-        if wait:
-            await wait_for_other_connections_to_close(conn)
+            if wait:
+                await wait_for_other_connections_to_close(conn)
 
-        if rollback:
-            stderr(f"Rolling back database to version {version}")
-            direction = "down"
-        else:
-            stderr(f"Migrating database to version {version}")
-            direction = "up"
+            if rollback:
+                stderr(f"Rolling back database to version {version}")
+                direction = "down"
+            else:
+                stderr(f"Migrating database to version {version}")
+                direction = "up"
 
-        await swoop_db.migrate(target=version, direction=direction, conn=conn)
-
-        await grant_connect_privileges(conn)
+            await swoop_db.migrate(target=version, direction=direction, conn=conn)
+        finally:
+            await grant_connect_privileges(conn)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Updates to database initialization and migration jobs for adding capability to revoke and grant connection privileges before and after running migrations, respectively

By revoking/granting connect privileges to the group role (`swoop_readwrite`), all member roles automatically get the same privileges as they are inherited from the group role. 